### PR TITLE
Proper error message in case of wrong config sections

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+# -*- conf -*-
+# flake8 settings for Spack.
+#
+# Below we describe which flake8 checks Spack ignores and what the
+# rationale is.
+#
+# Let people line things up nicely:
+# - E221: multiple spaces before operator
+# - E241: multiple spaces after ‘,’
+#
+# Spack allows wildcard imports:
+# - F403: disable wildcard import
+#
+# These are required to get the package.py files to test clean.
+# - F821: undefined name (needed for cmake, configure, etc.)
+# - F999: name name be undefined or undefined from star imports.
+#
+[flake8]
+ignore = E221,E241,F403,F821,F999
+max-line-length = 79

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 79

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,22 @@ before_install:
   # Need this for the git tests to succeed.
   - git config --global user.email "spack@example.com"
   - git config --global user.name "Test User"
+
   # Need this to be able to compute the list of changed files
   - git fetch origin develop:develop
 
 script:
+  # Regular spack setup and tests
   - . share/spack/setup-env.sh
   - spack compilers
   - spack config get compilers
   - spack install -v libdwarf
+
   # Run unit tests with code coverage
   - coverage run bin/spack test
-  # Checks if the file that have been changed are flake8 conformant
-  - CHANGED_PYTHON_FILES=`git diff develop... --name-only | perl -ne 'print if /\.py$/'`
-  - if [[ ${CHANGED_PYTHON_FILES} ]] ; then flake8 --format pylint --config flake8.ini ${CHANGED_PYTHON_FILES} ; fi
 
+  # Run flake8 code style checks.
+  - share/spack/qa/run-flake8
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ a [pull request](https://help.github.com/articles/using-pull-requests/).
 When you send your request, make ``develop`` the destination branch on the
 [Spack repository](https://github.com/LLNL/spack).
 
+Your contribution will need to pass all the tests run by the `spack test`
+command, as well as the formatting checks in `share/spack/qa/run-flake8`.
+You should run both of these before submitting your pull request, to
+ensure that the online checks succeed.
+
 Spack is using a rough approximation of the [Git
 Flow](http://nvie.com/posts/a-successful-git-branching-model/)
 branching model.  The ``develop`` branch contains the latest

--- a/flake8.ini
+++ b/flake8.ini
@@ -1,3 +1,0 @@
-[flake8]
-ignore = W391,F403,E221,F821
-max-line-length = 79

--- a/lib/spack/spack/architecture.py
+++ b/lib/spack/spack/architecture.py
@@ -34,14 +34,14 @@ import spack.error as serr
 
 class InvalidSysTypeError(serr.SpackError):
     def __init__(self, sys_type):
-        super(InvalidSysTypeError, self).__init__(
-            "Invalid sys_type value for Spack: " + sys_type)
+        super(InvalidSysTypeError,
+              self).__init__("Invalid sys_type value for Spack: " + sys_type)
 
 
 class NoSysTypeError(serr.SpackError):
     def __init__(self):
-        super(NoSysTypeError, self).__init__(
-            "Could not determine sys_type for this machine.")
+        super(NoSysTypeError,
+              self).__init__("Could not determine sys_type for this machine.")
 
 
 def get_sys_type_from_spack_globals():
@@ -69,15 +69,15 @@ def get_sys_type_from_platform():
 @memoized
 def sys_type():
     """Returns a SysType for the current machine."""
-    methods = [get_sys_type_from_spack_globals,
-               get_sys_type_from_environment,
+    methods = [get_sys_type_from_spack_globals, get_sys_type_from_environment,
                get_sys_type_from_platform]
 
     # search for a method that doesn't return None
     sys_type = None
     for method in methods:
         sys_type = method()
-        if sys_type: break
+        if sys_type:
+            break
 
     # Couldn't determine the sys_type for this machine.
     if sys_type is None:

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -269,10 +269,10 @@ config_scopes = OrderedDict()
 
 
 def validate_section_name(section):
-    """Raise a ValueError if the section is not a valid section."""
+    """Exit if the section is not a valid section."""
     if section not in section_schemas:
-        raise ValueError("Invalid config section: '%s'.  Options are %s"
-                         % (section, section_schemas))
+        tty.die("Invalid config section: '%s'. Options are: %s"
+                % (section, " ".join(section_schemas.keys())))
 
 
 def extend_with_default(validator_class):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -129,7 +129,6 @@ from ordereddict_backport import OrderedDict
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
-import copy
 
 import spack
 from spack.error import SpackError
@@ -306,12 +305,13 @@ def extend_with_default(validator_class):
             yield err
 
     return validators.extend(validator_class, {
-        "properties" : set_defaults,
-        "patternProperties" : set_pp_defaults
+        "properties": set_defaults,
+        "patternProperties": set_pp_defaults
     })
 
 
 DefaultSettingValidator = extend_with_default(Draft4Validator)
+
 
 def validate_section(data, schema):
     """Validate data read in from a Spack YAML file.
@@ -347,15 +347,13 @@ class ConfigScope(object):
         validate_section_name(section)
         return os.path.join(self.path, "%s.yaml" % section)
 
-
     def get_section(self, section):
-        if not section in self.sections:
+        if section not in self.sections:
             path   = self.get_section_filename(section)
             schema = section_schemas[section]
             data   = _read_config_file(path, schema)
             self.sections[section] = data
         return self.sections[section]
-
 
     def write_section(self, section):
         filename = self.get_section_filename(section)
@@ -369,7 +367,6 @@ class ConfigScope(object):
             raise ConfigSanityError(e, data)
         except (yaml.YAMLError, IOError) as e:
             raise ConfigFileError("Error writing to config file: '%s'" % str(e))
-
 
     def clear(self):
         """Empty cached config information."""
@@ -476,7 +473,7 @@ def _merge_yaml(dest, source):
     # Source dict is merged into dest.
     elif they_are(dict):
         for sk, sv in source.iteritems():
-            if not sk in dest:
+            if sk not in dest:
                 dest[sk] = copy.copy(sv)
             else:
                 dest[sk] = _merge_yaml(dest[sk], source[sk])
@@ -545,7 +542,10 @@ def update_config(section, update_data, scope=None):
     # read in the config to ensure we've got current data
     configuration = get_config(section)
 
-    configuration.update(update_data)
+    if isinstance(update_data, list):
+        configuration = update_data
+    else:
+        configuration.update(update_data)
 
     # read only the requested section's data.
     scope.sections[section] = {section: configuration}
@@ -587,22 +587,27 @@ def spec_externals(spec):
 def is_spec_buildable(spec):
     """Return true if the spec pkgspec is configured as buildable"""
     allpkgs = get_config('packages')
-    name = spec.name
-    if not spec.name in allpkgs:
+    if spec.name not in allpkgs:
         return True
-    if not 'buildable' in allpkgs[spec.name]:
+    if 'buildable' not in allpkgs[spec.name]:
         return True
     return allpkgs[spec.name]['buildable']
 
 
-class ConfigError(SpackError): pass
-class ConfigFileError(ConfigError): pass
+class ConfigError(SpackError):
+    pass
+
+
+class ConfigFileError(ConfigError):
+    pass
+
 
 def get_path(path, data):
     if path:
         return get_path(path[1:], data[path[0]])
     else:
         return data
+
 
 class ConfigFormatError(ConfigError):
     """Raised when a configuration format does not match its schema."""
@@ -637,6 +642,7 @@ class ConfigFormatError(ConfigError):
 
         message = '%s: %s' % (location, validation_error.message)
         super(ConfigError, self).__init__(message)
+
 
 class ConfigSanityError(ConfigFormatError):
     """Same as ConfigFormatError, raised when config is written by Spack."""

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 ##############################################################################
 # Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory.

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -72,6 +72,10 @@ b_comps = {
     }
 }
 
+# Some Sample repo data
+repos_low = [ "/some/path" ]
+repos_high = [ "/some/other/path" ]
+
 class ConfigTest(MockPackagesTest):
 
     def setUp(self):
@@ -94,6 +98,12 @@ class ConfigTest(MockPackagesTest):
                 expected = comps[arch][key][c]
                 actual = config[arch][key][c]
                 self.assertEqual(expected, actual)
+
+    def test_write_list_in_memory(self):
+        spack.config.update_config('repos', repos_low, 'test_low_priority')
+        spack.config.update_config('repos', repos_high, 'test_high_priority')
+        config = spack.config.get_config('repos')
+        self.assertEqual(config, repos_high+repos_low)
 
     def test_write_key_in_memory(self):
         # Write b_comps "on top of" a_comps.

--- a/share/spack/qa/run-flake8
+++ b/share/spack/qa/run-flake8
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# This script runs source code style checks on Spack.
+#
+# It should be executed from the top-level directory of the repo,
+# e.g.:
+#
+#    share/spack/qa/run-flake8
+#
+# To run it, you'll need to have the Python flake8 installed locally.
+#
+PYTHONPATH=./lib/spack:$PYTHONPATH
+
+flake8="$(which flake8)"
+if [[ ! $flake8 ]]; then
+    echo "ERROR: flake8 is required to run this script."
+    exit 1
+fi
+
+# Check if changed files are flake8 conformant [framework]
+changed=$(git diff --name-only develop... | grep '.py$')
+
+# Exempt url lines in changed packages from overlong line errors.
+for file in $changed; do
+    if [[ $file = *package.py ]]; then
+        perl -i~ -pe 's/^(\s*url\s*=.*)$/\1  # NOQA: ignore=E501/' $file;
+    fi
+done
+
+return_code=0
+if [[ $changed ]]; then
+    echo =======================================================
+    echo  flake8: running flake8 code checks on spack.
+    echo
+    echo  Modified files:
+    echo  $changed | perl -pe 's/^/  /;s/ +/\n  /g'
+    echo =======================================================
+    if flake8 --format pylint $changed; then
+        echo "Flake8 checks were clean."
+    else
+        echo "Flake8 found errors."
+        return_code=1
+    fi
+else
+    echo No core framework files modified.
+fi
+
+# Restore original package files after modifying them.
+for file in $changed; do
+    if [[ $file = *package.py ]]; then
+        mv "${file}~" "${file}"
+    fi
+done
+
+exit $return_code

--- a/var/spack/repos/builtin/packages/ImageMagick/package.py
+++ b/var/spack/repos/builtin/packages/ImageMagick/package.py
@@ -1,10 +1,11 @@
 from spack import *
 
+
 class Imagemagick(Package):
     """ImageMagick is a image processing library"""
     homepage = "http://www.imagemagic.org"
 
-    #-------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # ImageMagick does not keep around anything but *-10 versions, so
     # this URL may change.  If you want the bleeding edge, you can
     # uncomment it and see if it works but you may need to try to
@@ -17,14 +18,16 @@ class Imagemagick(Package):
     # version('6.9.0-6', 'c1bce7396c22995b8bdb56b7797b4a1b',
     # url="http://www.imagemagick.org/download/ImageMagick-6.9.0-6.tar.bz2")
 
-    #-------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # *-10 versions are archived, so these versions should fetch reliably.
     # -------------------------------------------------------------------------
-    version('6.8.9-10', 'aa050bf9785e571c956c111377bbf57c',
-            url="http://sourceforge.net/projects/imagemagick/files/old-sources/6.x/6.8/ImageMagick-6.8.9-10.tar.gz/download")
+    version(
+        '6.8.9-10',
+        'aa050bf9785e571c956c111377bbf57c',
+        url="http://sourceforge.net/projects/imagemagick/files/old-sources/6.x/6.8/ImageMagick-6.8.9-10.tar.gz/download")
 
-    depends_on('libtool')
     depends_on('jpeg')
+    depends_on('libtool')
     depends_on('libpng')
     depends_on('freetype')
     depends_on('fontconfig')
@@ -32,6 +35,5 @@ class Imagemagick(Package):
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
-
         make()
         make("install")

--- a/var/spack/repos/builtin/packages/Mitos/package.py
+++ b/var/spack/repos/builtin/packages/Mitos/package.py
@@ -1,19 +1,18 @@
 from spack import *
 
+
 class Mitos(Package):
     """Mitos is a library and a tool for collecting sampled memory
     performance data to view with MemAxes"""
 
     homepage = "https://github.com/llnl/Mitos"
-    url      = "https://github.com/llnl/Mitos"
+    url = "https://github.com/llnl/Mitos"
 
     version('0.9.2',
             git='https://github.com/llnl/Mitos.git',
             commit='8cb143a2e8c00353ff531a781a9ca0992b0aaa3d')
 
-    version('0.9.1',
-            git='https://github.com/llnl/Mitos.git',
-            tag='v0.9.1')
+    version('0.9.1', git='https://github.com/llnl/Mitos.git', tag='v0.9.1')
 
     depends_on('dyninst@8.2.1:')
     depends_on('hwloc')


### PR DESCRIPTION
Changes the behaviour towards invalid calls like `spack config edit notExisting` to
```
==> Error: Invalid config section: 'notExisting'. Options are: repos mirrors modules packages compilers
```
instead of 
```
Traceback (most recent call last):
  File "/Users/hegner/spack/bin/spack", line 176, in <module>
    main()
  File "/Users/hegner/spack/bin/spack", line 154, in main
    return_val = command(parser, args)
  File "/Users/hegner/spack/lib/spack/spack/cmd/config.py", line 69, in config
    action[args.config_command](args)
  File "/Users/hegner/spack/lib/spack/spack/cmd/config.py", line 62, in config_edit
    config_file = spack.config.get_config_filename(args.scope, args.section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 526, in get_config_filename
    return scope.get_section_filename(section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 348, in get_section_filename
    validate_section_name(section)
  File "/Users/hegner/spack/lib/spack/spack/config.py", line 275, in validate_section_name
    % (section, section_schemas))
ValueError: Invalid config section: 'notExisting'.  Options are {'repos': {'additionalProperties': False, 'patternProperties': {'repos:?': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack repository configuration file schema'}, 'mirrors': {'additionalProperties': False, 'patternProperties': {'mirrors:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'type': 'string'}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack mirror configuration file schema'}, 'modules': {'additionalProperties': False, 'patternProperties': {'modules:?': {'default': {}, 'additionalProperties': False, 'type': 'object', 'properties': {'enable': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack module file configuration file schema'}, 'packages': {'additionalProperties': False, 'patternProperties': {'packages:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'default': {}, 'additionalProperties': False, 'type': 'object', 'properties': {'buildable': {'default': True, 'type': 'boolean'}, 'paths': {'default': {}, 'type': 'object'}, 'version': {'default': [], 'items': {'anyOf': [{'type': 'string'}, {'type': 'number'}]}, 'type': 'array'}, 'providers': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}, 'type': 'object'}, 'compiler': {'default': [], 'items': {'type': 'string'}, 'type': 'array'}}}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack package configuration file schema'}, 'compilers': {'additionalProperties': False, 'patternProperties': {'compilers:?': {'default': {}, 'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*': {'additionalProperties': False, 'patternProperties': {'\\w[\\w-]*@\\w[\\w-]*': {'additionalProperties': False, 'required': ['cc', 'cxx', 'f77', 'fc'], 'type': 'object', 'properties': {'cc': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'cxx': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'f77': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}, 'fc': {'anyOf': [{'type': 'string'}, {'type': 'null'}]}}}}, 'type': 'object'}}, 'type': 'object'}}, '$schema': 'http://json-schema.org/schema#', 'type': 'object', 'title': 'Spack compiler configuration file schema'}}
```